### PR TITLE
Reserved label 'drafts'

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -35,7 +35,7 @@ extra_args = {'prettyPrint': False}
 allLabelIds = dict()
 allLabels = dict()
 chunksize = 1024 * 1024 * 30
-reserved_labels = ['chat', 'chats', 'migrated', 'todo', 'todos', 'buzz', 'bin', 'allmail']
+reserved_labels = ['chat', 'chats', 'migrated', 'todo', 'todos', 'buzz', 'bin', 'allmail', 'drafts']
 
 import argparse
 import sys


### PR DESCRIPTION
`'drafts'` needs to be added to the list of reserved labels - currently messages with explicit `Drafts` label cause gyb to exit with `400: Invalid label name - invalidArgument`. Related to #82 