### PR TITLE
Ignore compressed tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ privatekey.p12
 # builds
 *.zip
 *.exe
+*.tar.xz


### PR DESCRIPTION
Ignore the compressed tar file output from the Mac OS build process.