### PR TITLE
Fix for common invalid label error

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -36,7 +36,7 @@ allLabelIds = dict()
 allLabels = dict()
 reserved_labels = ['inbox', 'spam', 'trash', 'unread', 'starred', 'important',
   'sent', 'draft', 'chat', 'chats', 'migrated', 'todo', 'todos', 'buzz',
-  'bin', 'allmail', 'drafts']
+  'bin', 'allmail', 'drafts', 'archived']
 
 import argparse
 import sys
@@ -1708,7 +1708,7 @@ def main(argv):
                 labels_str = mybytes.decode(encoding)
               except UnicodeDecodeError:
                 pass
-            labels = labels_str.split(',')
+            labels = labels_str.rstrip().split(',')
           cased_labels = []
           for label in labels:
             if label == '' or label == None:


### PR DESCRIPTION
When I encountered this 400 invalid label invalidArgument problem, it was because something ending in `\r` was being submitted as a label.  This has come up in #82 and #135 and may underlie other similar issues.  The mail header for labels is read without stripping whitespace, so I've just added an `rstrip()` call on the line where the decoded header gets comma-split to a list of labels.  This fixed the problem for me.

Also adds 'archived' as a reserved label.