### PR TITLE
Fix sqlite errors on restore with no new messages.

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -1665,6 +1665,7 @@ def main(argv):
       callGAPI(gbatch, None, soft_errors=True)
       sqlconn.commit()
     print("\n")
+    sqlconn.commit()
     sqlconn.execute('DETACH resume')
     sqlconn.commit()
 


### PR DESCRIPTION
This patch fixes sqlite operational errors on restore when there are no new messages.

After running a full restore, run `gyb` again to ensure that all messages have been included:

```
$ gyb --email user@gmail.example.com \
      --action restore --local-folder user@gmail.example.com \
      --fast-restore

Traceback (most recent call last):
  File "gyb.py", line 2072, in <module>
  File "gyb.py", line 1682, in main
sqlite3.OperationalError: cannot DETACH database within transaction
[3477] Failed to execute script gyb
```

The traceback is the result of the restore code's cleanup call to `sqlconn.execute('DETACH resume')`. The sqlite queries at the start of restore put the code into an implicit transaction with sqlite until a COMMIT is invoked. Before this patch, all COMMITs are in the for-loop, and when there are no messages, the for-loop is not run and no such COMMIT is invoked. After this patch, the program runs to completion without error.

While verifying this patch in a test build, I also came across this error before the patch was applied:

```
$ gyb --email user@gmail.example.com \
      --action restore --local-folder user@gmail.example.com \
      --fast-restore

Traceback (most recent call last):
  File "gyb.py", line 2072, in <module>
  File "gyb.py", line 1682, in main
sqlite3.OperationalError: database resume is locked
[30955] Failed to execute script gyb
```

This "database resume is locked" error is also resolved by the patch included in this pull request, which suggests that at least one of the scenarios (when there are no new messages to restore) reported in #179 is fixed by this patch.

I'm running gyb v1.27 on GNU/Linux x86_64.