### PR TITLE
Fix install-gyb.sh on MacOS

### DIFF
--- a/install-gyb.sh
+++ b/install-gyb.sh
@@ -135,7 +135,7 @@ case $myos in
       echo_red "Sorry, you need to be running at least MacOS $macos_ver to run GAM"
       exit
     fi
-    gamfile="macos-x86_64-$use_macos_ver.tar.xz"
+    gybfile="macos-x86_64-$use_macos_ver.tar.xz"
     ;;
   *)
     echo_red "Sorry, this installer currently only supports Linux and MacOS. Looks like you're runnning on $myos. Exiting."


### PR DESCRIPTION
s/gamfile/gybfile/

before:
```
➜  ./install-gyb.sh
You are running MacOS 10.15.2

Using GYB compiled on MacOS10.14.4

Checking GitHub URL https://api.github.com/repos/jay0lee/got-your-back/releases for  GYB release...

Getting file and download URL...

Downloading file gyb-1.34-linux-arm64-glibc2.23.tar.xz from https://github.com/jay0lee/got-your-back/releases/download/v1.34/gyb-1.34-linux-arm64-glibc2.23.tar.xz to /var/folders/24/3glhd_n144g_6z59ys47xhk00000gn/T/tmp.HTVlU6vm.
```

after:
```
➜  ./install-gyb.sh
You are running MacOS 10.15.2

Using GYB compiled on MacOS10.14.4

Checking GitHub URL https://api.github.com/repos/jay0lee/got-your-back/releases for  GYB release...

Getting file and download URL...

Downloading file gyb-1.34-macos-x86_64-MacOS10.14.4.tar.xz from https://github.com/jay0lee/got-your-back/releases/download/v1.34/gyb-1.34-macos-x86_64-MacOS10.14.4.tar.xz to /var/folders/24/3glhd_n144g_6z59ys47xhk00000gn/T/tmp.iBmssxvV.
```