### PR TITLE
Adds rate limiting to comply with Google's API rate limits

### DIFF
--- a/gyb.py
+++ b/gyb.py
@@ -354,8 +354,14 @@ class QuotaBucket:
       my_event.wait()
 
 
+class UnlimitedBucket:
+  def get(self, method):
+    return
+
+
 # bucket names are the first segment of the method ID
 buckets = {
+    "drive": UnlimitedBucket(),
     "gmail": QuotaBucket(250, 0.5, 125),
     "groupsmigration": QuotaBucket(10, 1, 10),
 }

--- a/gyb.py
+++ b/gyb.py
@@ -280,10 +280,11 @@ def getQuota(method):
     try:
       bucket_name = m.split(".")[0]
       bucket = buckets[bucket_name]
+    except KeyError:
+      # the base API group does not have quota support
+      continue
     except IndexError:
       systemErrorExit(1, "empty method ID")
-    except KeyError:
-      systemErrorExit(1, "no quota bucket for " + bucket_name)
 
     bucket.get(m)
 
@@ -354,14 +355,10 @@ class QuotaBucket:
       my_event.wait()
 
 
-class UnlimitedBucket:
-  def get(self, method):
-    return
-
-
-# bucket names are the first segment of the method ID
+# Bucket names are the first segment of the method ID. Start here if you need
+# to add rate limiting for an API group. Then add methods to the GOOGLEQUOTAS
+# dictionary above.
 buckets = {
-    "drive": UnlimitedBucket(),
     "gmail": QuotaBucket(250, 0.5, 125),
     "groupsmigration": QuotaBucket(10, 1, 10),
 }


### PR DESCRIPTION
Pulls tokens from a simple token bucket prior to making an API call
or adding a specific call to a batch. Google documents its rate limits
as a moving average:

https://developers.google.com/gmail/api/reference/quota
https://developers.google.com/admin-sdk/groups-migration/v1/reference/archive/insert

I used this change successfully to backup and restore an account with
26,000 messages. Without this change it had been hitting the rate limit.

fixes #287